### PR TITLE
run breakpoints from API in vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # fs
 .DS_Store
-.vscode
+#.vscode
 !.vscode/settings.json
+!.vscode/launch.json
 
 coverage
 node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "API",
+            "protocol": "inspector",
+            "port": 7001,
+            "restart": true,
+            "localRoot": "${workspaceRoot}",
+            "remoteRoot": "."
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "WEB",
+            "protocol": "inspector",
+            "port": 7000,
+            "restart": true,
+            "localRoot": "${workspaceRoot}",
+            "remoteRoot": "."
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "private": true,
     "license": "MIT",
     "engines": {
-        "node": "^10.16.x",
-        "yarn": ">= 1.17.3"
+        "node": ">= 10.16.x",
+        "yarn": ">= 1.16.0"
     },
     "scripts": {
         "postinstall": "lerna exec -- yarn install && lerna run prepare",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -9,8 +9,8 @@
     "url": "maapteh/graphql-modules-app/packages/graphql-app"
   },
   "engines": {
-    "node": "^10.16.x",
-    "yarn": ">= 1.17.3"
+    "node": ">= 10.16.x",
+    "yarn": ">= 1.16.0"
   },
   "scripts": {
     "prepare": "yarn build",
@@ -91,6 +91,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "24.9.0",
     "lint-staged": "9.4.2",
+    "mq-polyfill": "1.1.8",
     "react-test-renderer": "16.11.0",
     "ts-jest": "24.1.0"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,14 +10,14 @@
   "pre-commit": "lint-staged",
   "license": "MIT",
   "engines": {
-    "node": "^10.16.x",
-    "yarn": ">= 1.17.3"
+    "node": ">= 10.16.x",
+    "yarn": ">= 1.16.0"
   },
   "scripts": {
     "prepare": "yarn build",
     "precommit": "lint-staged",
     "audit": "yarn audit",
-    "dev": "NODE_ENV=development ts-node-dev --respawn --transpileOnly ./src/index.ts",
+    "dev": "NODE_ENV=development ts-node-dev --respawn --inspect=7001 --transpileOnly ./src/index.ts",
     "dev:monitoring": "yarn build && pm2-runtime dist/index.js",
     "dev:debug": "ts-node-dev --inspect --debug-brk ./src/index.ts",
     "test": "jest --config=jest.config.js",


### PR DESCRIPTION
when running `yarn start` inside vscode you can attach debugger on the inspect port 7001 of the API by running `API` in the debug panel of vscode. This will make debugging much more easier.